### PR TITLE
:sparkles: トップページで未来のイベントが表示され、過去のイベントは非表示であることを確認するシステムテストを追加

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,4 +64,6 @@ RSpec.configure do |config|
 
   OmniAuth.config.test_mode = true
   config.include SignInHelper
+
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/system/welcomes_spec.rb
+++ b/spec/system/welcomes_spec.rb
@@ -6,4 +6,15 @@ RSpec.describe 'Welcome Page', type: :system do
 
     expect(page).to have_selector 'h1', text: 'イベント一覧'
   end
+
+  it '/ページで未来のイベントが表示され、過去のイベントが非表示であること' do
+    future_event = FactoryBot.create(:event, start_at: Time.zone.now + 3.day)
+    past_event = FactoryBot.create(:event, start_at: Time.zone.now)
+
+    travel_to Time.zone.now + 1.day do
+      visit root_path
+      assert_selector 'h5', text: future_event.name
+      assert_no_selector 'h5', text: past_event.name
+    end
+  end
 end


### PR DESCRIPTION
<img width="925" alt="スクリーンショット 2022-09-26 16 08 36" src="https://user-images.githubusercontent.com/26560390/192214395-700cb890-8a18-4d06-b37f-c6f8301fb5b4.png">
